### PR TITLE
Bug Fix

### DIFF
--- a/lib/crossword.dart
+++ b/lib/crossword.dart
@@ -70,6 +70,9 @@ class CrosswordState extends State<Crossword> {
     // TODO: implement didUpdateWidget
     super.didUpdateWidget(oldWidget);
     letters = widget.transposeMatrix! ?widget.letters: widget.letters.transpose();
+    lineList = [];
+    selectedOffsets = [];
+    updatedLineList = [];
   }
 
   //check whether user interaction on the panel within the letter positions limit or outside the area


### PR DESCRIPTION
{Fixed}(https://github.com/Amonc/crossword/issues/3) the issue about the Matrix not updating.

The letters variable was only initialized in initstate, hence changes could not be displayed since initstate is run only once when the widget is built.

I added a didUpdateWidget function which is automatically called when changes occur in the parent widget that affect the widget. The letters variable is then updated with the new matrix passed in. And other necessary variables are reinitialized again