### PR TITLE
Added Optional Overlap Feature.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -71,7 +71,6 @@ class _GamePageState extends State<GamePage> {
     return Scaffold(
         backgroundColor: Colors.black,
         body: Crossword(
-
           letters: const [
             ["F", "L", "U", "T", "T", "E", "R", "W", "U", "D", "B", "C"],
             ["R", "M", "I", "O", "P", "U", "I", "Q", "R", "L", "E", "G"],
@@ -91,6 +90,7 @@ class _GamePageState extends State<GamePage> {
           lineDecoration:
               LineDecoration(lineColors: lineColors, strokeWidth: 20),
           hints: const ["FLUTTER", "GAMES", "UI", "COLORS"],
+          overlap: true,
         ));
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -90,7 +90,7 @@ class _GamePageState extends State<GamePage> {
           lineDecoration:
               LineDecoration(lineColors: lineColors, strokeWidth: 20),
           hints: const ["FLUTTER", "GAMES", "UI", "COLORS"],
-          overlap: true,
+          allowOverlap: true,
         ));
   }
 }

--- a/lib/crossword.dart
+++ b/lib/crossword.dart
@@ -23,7 +23,7 @@ class Crossword extends StatefulWidget {
   final List<String> hints;
   final TextStyle? textStyle;
   final bool? acceptReversedDirection;
-  final bool overlap;
+  final bool? allowOverlap;
 
   const Crossword({
     super.key,
@@ -38,7 +38,7 @@ class Crossword extends StatefulWidget {
     this.textStyle,
     this.acceptReversedDirection = false,
     this.transposeMatrix = false,
-    this.overlap = false,
+    this.allowOverlap = false,
   }) : assert(
           (drawCrossLine ?? true) ||
               (drawHorizontalLine ?? true) ||
@@ -218,7 +218,7 @@ class CrosswordState extends State<Crossword> {
 
                 setState(() {
                   ///Check if the line can be drawn on specific angles
-                  if ((widget.overlap ||
+                  if ((widget.allowOverlap! ||
                           selectedOffsets
                               .toSet()
                               .intersection(usedOffsets.toSet())

--- a/lib/crossword.dart
+++ b/lib/crossword.dart
@@ -23,21 +23,23 @@ class Crossword extends StatefulWidget {
   final List<String> hints;
   final TextStyle? textStyle;
   final bool? acceptReversedDirection;
+  final bool overlap;
 
-  const Crossword(
-      {super.key,
-      required this.letters,
-      required this.spacing,
-      this.drawCrossLine,
-      required this.onLineDrawn,
-      this.drawHorizontalLine,
-      this.drawVerticalLine,
-      required this.hints,
-      this.lineDecoration = const LineDecoration(),
-      this.textStyle,
-      this.acceptReversedDirection = false,
-      this.transposeMatrix = false})
-      : assert(
+  const Crossword({
+    super.key,
+    required this.letters,
+    required this.spacing,
+    this.drawCrossLine,
+    required this.onLineDrawn,
+    this.drawHorizontalLine,
+    this.drawVerticalLine,
+    required this.hints,
+    this.lineDecoration = const LineDecoration(),
+    this.textStyle,
+    this.acceptReversedDirection = false,
+    this.transposeMatrix = false,
+    this.overlap = false,
+  }) : assert(
           (drawCrossLine ?? true) ||
               (drawHorizontalLine ?? true) ||
               (drawVerticalLine ?? true),
@@ -216,10 +218,11 @@ class CrosswordState extends State<Crossword> {
 
                 setState(() {
                   ///Check if the line can be drawn on specific angles
-                  if (selectedOffsets
-                          .toSet()
-                          .intersection(usedOffsets.toSet())
-                          .isEmpty &&
+                  if ((widget.overlap ||
+                          selectedOffsets
+                              .toSet()
+                              .intersection(usedOffsets.toSet())
+                              .isEmpty) &&
                       lineList.last.offsets
                               .map((e) => e.getSmallerOffset)
                               .toSet()


### PR DESCRIPTION
This Pull Request introduces a new optional feature to the Flutter crossword package, allowing users to drag words overlapping in the crossword grid. This feature enhances the user experience by providing more flexibility in solving puzzles.

## Changes Made
- Implemented the ability for words to be dragged and placed in overlapping positions within the crossword grid.
- Added new parameters to control the overlapping behavior, making it an optional feature for users.

## How to Use
To enable the overlapping feature, users can set the `overlap` parameter to `true` when initializing the crossword widget.

## Screenshots
![crosswrod](https://github.com/Amonc/crossword/assets/103190168/108eb455-aa35-43d3-9cc4-cdbb3398d76b)
The screenshot shows how overlaping works

Thank you for considering this pull request! Feel free to reach out if there are any additional changes or improvements needed.